### PR TITLE
Updated `Mix.Dep.loaded/0` call to `Mix.Dep.cached/0`

### DIFF
--- a/lib/licensir/scanner.ex
+++ b/lib/licensir/scanner.ex
@@ -44,7 +44,7 @@ defmodule Licensir.Scanner do
     if Keyword.has_key?(Mix.Dep.__info__(:functions), :load_on_environment) do
       :load_on_environment
     else
-      :loaded
+      :cached
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Licensir.Mixfile do
     [
       app: :licensir,
       version: @version,
-      elixir: "~> 1.5",
+      elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       escript: [main_module: Licensir.Licenses],
       name: "Licensir",


### PR DESCRIPTION
Bumps Elixir version to `1.8` - when `loaded` was removed